### PR TITLE
Replace default widget test with WishlistApp placeholder

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,11 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:wishlist/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
-  });
+  testWidgets('WishlistApp shows loading indicator', (tester) async {
+    await tester.pumpWidget(const WishlistApp());
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  }, skip: 'Firebase is not initialized for widget tests.');
 }


### PR DESCRIPTION
## Summary
- Replace counter scaffold with skeleton test for `WishlistApp`
- Skip test until Firebase can be initialized in widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68985c9de2fc8326af95ed90fe6b1d5a