### PR TITLE
Add wishlist invitation model and security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,37 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /wishlists/{listId} {
+      allow read, write: if request.auth != null; // dev only
+
+      match /items/{itemId} {
+        allow read, write: if request.auth != null; // dev only
+      }
+      
+      match /reservations/{rid} {
+        allow read: if isOwner(listId) || isGuest(listId);
+        allow create: if isGuest(listId);
+        allow update, delete: if isOwner(listId) || isSelfReservation(listId, rid);
+      }
+    }
+
+    match /wishlistInvites/{inviteId} {
+      allow create: if request.auth != null &&
+        request.auth.uid == request.resource.data.ownerId;
+      allow read, update: if request.auth != null &&
+        (request.auth.uid == resource.data.ownerId ||
+         request.auth.token.email == resource.data.email);
+      allow delete: if request.auth != null &&
+        request.auth.uid == resource.data.ownerId;
+    }
+  }
+  
+  function isOwner(listId) { return resource.data.ownerId == request.auth.uid; }
+  function isGuest(listId) { return exists(/databases/$(database)/documents/wishlists/$(listId)/members/$(request.auth.uid)); }
+  function isPublic(listId) { return get(/databases/$(database)/documents/wishlists/$(listId)).data.visibility == "public"; }
+  function parentPerm(listId) { return isOwner(listId) || isGuest(listId) || isPublic(listId); }
+  function isSelfReservation(listId, rid) {
+    return get(/databases/$(database)/documents/wishlists/$(listId)/reservations/$(rid)).data.byUserIdHash == hmac(request.auth.uid);
+  }
+}

--- a/lib/models/invitation.dart
+++ b/lib/models/invitation.dart
@@ -1,0 +1,51 @@
+import 'ids.dart';
+import 'invite_status.dart';
+
+/// Firestore document stored at `/wishlistInvites/{id}`.
+///
+/// Represents an email invitation to join a wishlist.
+class Invitation {
+  final DocID id;
+  final UID ownerId; // who sent the invite
+  final String email; // invited person's email
+  final DocID wishlistId; // associated wishlist
+  final InviteStatus status;
+  final int createdAtMs;
+  final int updatedAtMs;
+
+  const Invitation({
+    required this.id,
+    required this.ownerId,
+    required this.email,
+    required this.wishlistId,
+    required this.status,
+    required this.createdAtMs,
+    required this.updatedAtMs,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'ownerId': ownerId,
+        'email': email,
+        'wishlistId': wishlistId,
+        'status': status.name,
+        'createdAtMs': createdAtMs,
+        'updatedAtMs': updatedAtMs,
+      };
+
+  factory Invitation.fromMap(
+    DocID id,
+    Map<String, dynamic> m,
+  ) =>
+      Invitation(
+        id: id,
+        ownerId: m['ownerId'] as String,
+        email: m['email'] as String,
+        wishlistId: m['wishlistId'] as String,
+        status: InviteStatus.values.firstWhere(
+          (e) => e.name == m['status'],
+        ),
+        createdAtMs: (m['createdAtMs'] as num).toInt(),
+        updatedAtMs: (m['updatedAtMs'] as num).toInt(),
+      );
+}
+

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -9,6 +9,7 @@ import 'package:wishlist/models/member_role.dart';
 import 'package:wishlist/models/invite_status.dart';
 import 'package:wishlist/models/wishlist.dart';
 import 'package:wishlist/models/wishlist_visibility.dart';
+import 'package:wishlist/models/invitation.dart';
 
 void main() {
   group('Model mapping', () {
@@ -88,6 +89,21 @@ void main() {
       );
       final map = list.toMap();
       final from = Wishlist.fromMap(list.id, map);
+      expect(from.toMap(), equals(map));
+    });
+
+    test('Invitation round trip', () {
+      final invite = Invitation(
+        id: 'inv1',
+        ownerId: 'owner1',
+        email: 'friend@example.com',
+        wishlistId: 'list1',
+        status: InviteStatus.pending,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+      );
+      final map = invite.toMap();
+      final from = Invitation.fromMap(invite.id, map);
       expect(from.toMap(), equals(map));
     });
   });


### PR DESCRIPTION
## Summary
- add Invitation model storing owner, email, status and wishlist
- document collection `/wishlistInvites` in Firestore rules merged with existing wishlist rules
- cover invitation mapping with unit test

## Testing
- `dart format firestore.rules lib/models/invitation.dart test/models_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689863e446dc8326ab9814d423f9b2b4