### PR TITLE
Add wishlist invitation flow with share sheet

### DIFF
--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:uuid/uuid.dart';
+
+class InvitationService {
+  final _db = FirebaseFirestore.instance;
+  CollectionReference<Map<String, dynamic>> get _col =>
+      _db.collection('wishlistInvites');
+
+  /// Creates a new invitation document and returns the shareable link.
+  Future<String> createInvitation({
+    required String wishlistId,
+    required String email,
+  }) async {
+    final uid = FirebaseAuth.instance.currentUser!.uid;
+    final token = const Uuid().v4();
+    final now = DateTime.now().millisecondsSinceEpoch;
+
+    await _col.doc(token).set({
+      'ownerId': uid,
+      'email': email,
+      'wishlistId': wishlistId,
+      'status': 'pending',
+      'createdAtMs': now,
+      'updatedAtMs': now,
+    });
+
+    return 'https://wishlist.example/invite/$token';
+  }
+}
+

--- a/lib/widgets/invite_form.dart
+++ b/lib/widgets/invite_form.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../services/invitation_service.dart';
+
+class InviteForm extends StatefulWidget {
+  final String wishlistId;
+  const InviteForm({super.key, required this.wishlistId});
+
+  @override
+  State<InviteForm> createState() => _InviteFormState();
+}
+
+class _InviteFormState extends State<InviteForm> {
+  final _email = TextEditingController();
+  final _svc = InvitationService();
+  bool _sending = false;
+  final _emailRegex = RegExp(r'^[^@]+@[^@]+\.[^@]+$');
+
+  Future<void> _submit() async {
+    final email = _email.text.trim();
+    if (!_emailRegex.hasMatch(email)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Enter a valid email')),
+      );
+      return;
+    }
+    setState(() => _sending = true);
+    try {
+      final link = await _svc.createInvitation(
+        email: email,
+        wishlistId: widget.wishlistId,
+      );
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      await Share.share(link, subject: 'Join my wishlist');
+    } finally {
+      if (mounted) setState(() => _sending = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 16,
+        bottom: 16 + MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Invite member',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _email,
+            keyboardType: TextInputType.emailAddress,
+            decoration: const InputDecoration(labelText: 'Email'),
+          ),
+          const SizedBox(height: 12),
+          FilledButton(
+            onPressed: _sending ? null : _submit,
+            child: Text(_sending ? 'Sending…' : 'Send invite'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/wishlist_page.dart
+++ b/lib/wishlist_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import 'add_wishlist_item_page.dart';
 import 'widgets/wishlist_form.dart';
+import 'widgets/invite_form.dart';
 
 class WishlistPage extends StatelessWidget {
   final String listId;
@@ -219,23 +220,26 @@ class WishlistPage extends StatelessWidget {
                 },
               ),
 
-              const SizedBox(height: 24),
+          if (isOwner) ...[
+            const SizedBox(height: 24),
 
-              // Placeholder for invite/link (coming next)
-              const Text(
-                'Invite',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-              ),
-              const SizedBox(height: 12),
-              OutlinedButton.icon(
-                icon: const Icon(Icons.link),
-                label: const Text('Get invite link'),
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Invite link — coming soon')),
-                  );
-                },
-              ),
+            const Text(
+              'Invite',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.person_add),
+              label: const Text('Invite by email'),
+              onPressed: () {
+                showModalBottomSheet(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (_) => InviteForm(wishlistId: listId),
+                );
+              },
+            ),
+          ],
             ],
           ),
           floatingActionButton: FloatingActionButton.extended(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   firebase_storage: ^13.0.0
   image_picker: ^1.1.2
   cached_network_image: ^3.3.1
+  share_plus: ^7.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `share_plus` dependency
- implement `InvitationService` to generate invite token and Firestore document
- add `InviteForm` widget to validate email, send invite, and share link
- update `WishlistPage` with invite button for owners

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689870241bb8832691c3144415644c1f